### PR TITLE
'upgrade' name conflict

### DIFF
--- a/Sources/Request+JSON.swift
+++ b/Sources/Request+JSON.swift
@@ -26,8 +26,8 @@
 @_exported import JSON
 
 extension Request {
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], json: JSON,
-                didUpgrade: DidUpgrade? = nil) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:],
+                json: JSON, didUpgrade: DidUpgrade? = nil) {
         var headers = headers
         headers["content-type"] = "application/json; charset=utf-8"
         self.init(

--- a/Sources/Request+JSON.swift
+++ b/Sources/Request+JSON.swift
@@ -26,7 +26,8 @@
 @_exported import JSON
 
 extension Request {
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], json: JSON, didUpgrade: DidUpgrade? = nil) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], json: JSON,
+                didUpgrade: DidUpgrade? = nil) {
         var headers = headers
         headers["content-type"] = "application/json; charset=utf-8"
         self.init(

--- a/Sources/Request+JSON.swift
+++ b/Sources/Request+JSON.swift
@@ -26,7 +26,7 @@
 @_exported import JSON
 
 extension Request {
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], json: JSON, upgrade: Upgrade? = nil) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], json: JSON, didUpgrade: DidUpgrade? = nil) {
         var headers = headers
         headers["content-type"] = "application/json; charset=utf-8"
         self.init(
@@ -34,7 +34,7 @@ extension Request {
             uri: uri,
             headers: headers,
             body: json.description,
-            upgrade: upgrade
+            didUpgrade: didUpgrade
         )
     }
 }

--- a/Sources/Response+JSON.swift
+++ b/Sources/Response+JSON.swift
@@ -27,14 +27,14 @@ import enum HTTP.Status
 import enum JSON.JSON
 
 extension Response {
-    public init(status: Status = .ok, headers: Headers = [:], json: JSON, upgrade: Upgrade? = nil) {
+    public init(status: Status = .ok, headers: Headers = [:], json: JSON, didUpgrade: DidUpgrade? = nil) {
         var headers = headers
         headers["content-type"] = "application/json; charset=utf-8"
         self.init(
             status: status,
             headers: headers,
             body: json.description,
-            upgrade: upgrade
+            didUpgrade: didUpgrade
         )
     }
 }

--- a/Sources/Response+JSON.swift
+++ b/Sources/Response+JSON.swift
@@ -27,7 +27,8 @@ import enum HTTP.Status
 import enum JSON.JSON
 
 extension Response {
-    public init(status: Status = .ok, headers: Headers = [:], json: JSON, didUpgrade: DidUpgrade? = nil) {
+    public init(status: Status = .ok, headers: Headers = [:], json: JSON,
+                didUpgrade: DidUpgrade? = nil) {
         var headers = headers
         headers["content-type"] = "application/json; charset=utf-8"
         self.init(


### PR DESCRIPTION
'upgrade' name conflict
## Problem

Message and Request both uses “upgrade”
## Reason

S4 Defines Request is following protocol but upgrade for two different
reason.

```
public struct Request: Message {
```
## Fix

request.upgrade changes to
request.didUpgrade since this is callback function

sending all related
Zewo/HTTP
VeniceX/HTTPClient
VeniceX/HTTPSClient
VeniceX/HTTPServer
VeniceX/HTTPSServer
PR

Also Stroage[""] Parameter should be consistent
for Request use storage["request-upgrade"]
for Response use  storage["response-connection-upgrade"]
consistencely
